### PR TITLE
Update Checkout.php

### DIFF
--- a/lib/Checkout.php
+++ b/lib/Checkout.php
@@ -95,6 +95,13 @@ class Checkout extends SumupObject
             self::API_ENDPOINT,
             new Checkout($params)
         );
+        
+        $code = $response->raw->getStatusCode();
+        if ($code !== 200) {
+            throw new Error\ApiRequestorError(
+                json_encode($response->data), $code
+            );
+        }
 
         return new Checkout($response->toArray());
     }


### PR DESCRIPTION
SUMUP throw predefined errors: 400,401,404,409 and 500.
This turns the Http errors to be visible outside.